### PR TITLE
replace process exit with a notify in order to properly call destructors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,12 +19,24 @@ type Follows = HashSet<u64>;
 const REQUESTED_FOLLOWS_CHANNEL_CAPACITY: usize = 16;
 const TWEET_CHANNEL_CAPACITY: usize = 16;
 
-#[tokio::main]
-async fn main() {
-    if let Err(error) = run().await {
+fn main() {
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let mut failure = false;
+
+    if let Err(error) = rt.block_on(run()) {
         log::error!("fatal: {:#}", error);
+        failure = true;
+    }
+
+    log::info!("waiting one second for tasks to end");
+    rt.shutdown_timeout(std::time::Duration::from_secs(1));
+
+    if failure {
+        log::error!("error exit");
         std::process::exit(1);
     }
+
+    log::info!("exiting");
 }
 
 async fn run() -> Result<()> {
@@ -87,11 +99,11 @@ async fn run() -> Result<()> {
         }
 
         _ = lifeline.notified() => {
-            log::info!("lifeline cut, exiting");
+            log::info!("lifeline cut, shutting down");
         }
 
         _ = tokio::signal::ctrl_c() => {
-            log::info!("interrupted, exiting");
+            log::info!("interrupted, shutting down");
         }
     }
 

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -105,7 +105,24 @@ async fn handler(
             }
 
             tweet = rx_tweet.next() => {
-                let tweet = tweet.context("fused stream to rx_tweet ran out")?;
+                let tweet = match tweet {
+                    Some(tweet) => tweet,
+                    None => {
+                        // rx_tweet ran out, hopefully we're shutting down
+
+                        use async_tungstenite::tungstenite::protocol;
+
+                        log::info!("closing {}", addr);
+                        tx_ws
+                            .send(Message::Close(Some(protocol::CloseFrame {
+                                code: protocol::frame::coding::CloseCode::Error,
+                                reason: "tweet-provider was interrupted or encountered an error".into(),
+                            })))
+                        .await?;
+
+                        break;
+                    }
+                };
 
                 if let Err(broadcast::RecvError::Lagged(n)) = tweet {
                     log::error!("lagging {} items behind", n);
@@ -134,6 +151,8 @@ async fn handler(
             }
         }
     }
+
+    Ok(())
 }
 
 async fn handle_ws_message<S>(
@@ -184,6 +203,7 @@ where
         Ok(api::ClientMessage::Exit) => {
             log::warn!("client {} requested exit", addr);
             lifeline.notify();
+            return Ok(());
         }
 
         Ok(api::ClientMessage::SetSubscriptions(new_follows)) => {

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -6,10 +6,10 @@ use async_tungstenite::{
 };
 use egg_mode::tweet::Tweet;
 use futures::{sink::Sink, FutureExt, SinkExt, StreamExt};
-use std::{net::SocketAddr, ops::Not, time::Duration};
+use std::{net::SocketAddr, ops::Not, sync::Arc, time::Duration};
 use tokio::{
     net::{TcpListener, TcpStream},
-    sync::{broadcast, mpsc},
+    sync::{broadcast, mpsc, Notify},
     time::{interval_at, timeout, Instant},
 };
 
@@ -21,6 +21,7 @@ pub async fn listener(
     mut listener: TcpListener,
     tx_requested_follows: mpsc::Sender<(SocketAddr, Follows)>,
     tx_tweet: broadcast::Sender<Tweet>,
+    lifeline: &Arc<Notify>,
 ) -> Result<()> {
     log::info!("listening on {}", listener.local_addr().unwrap());
 
@@ -32,8 +33,16 @@ pub async fn listener(
                 let mut tx_requested_follows = tx_requested_follows.clone();
                 let rx_tweet = tx_tweet.subscribe();
 
+                let lifeline_clone = lifeline.clone();
                 tokio::spawn(async move {
-                    let res = handler(stream, addr, &mut tx_requested_follows, rx_tweet).await;
+                    let res = handler(
+                        stream,
+                        addr,
+                        &mut tx_requested_follows,
+                        rx_tweet,
+                        lifeline_clone,
+                    )
+                    .await;
 
                     if let Err(error) = res {
                         if let Some(WsError::ConnectionClosed) = error.downcast_ref() {
@@ -60,6 +69,7 @@ async fn handler(
     addr: SocketAddr,
     tx_requested_follows: &mut mpsc::Sender<(SocketAddr, Follows)>,
     rx_tweet: broadcast::Receiver<Tweet>,
+    lifeline: Arc<Notify>,
 ) -> Result<()> {
     let mut follows = Follows::new();
 
@@ -89,6 +99,7 @@ async fn handler(
                     &mut follows,
                     &mut tx_ws,
                     tx_requested_follows,
+                    &lifeline,
                 )
                 .await?;
             }
@@ -131,6 +142,7 @@ async fn handle_ws_message<S>(
     follows: &mut Follows,
     mut tx_ws: S,
     tx_requested_follows: &mut mpsc::Sender<(SocketAddr, Follows)>,
+    lifeline: &Arc<Notify>,
 ) -> Result<()>
 where
     S: Sink<Message> + Send + Sync + Unpin,
@@ -171,7 +183,7 @@ where
 
         Ok(api::ClientMessage::Exit) => {
             log::warn!("client {} requested exit", addr);
-            std::process::exit(0);
+            lifeline.notify();
         }
 
         Ok(api::ClientMessage::SetSubscriptions(new_follows)) => {


### PR DESCRIPTION
draft for now, this will be required if we solve #9 by sending close frames on drop