### PR TITLE
Send close frames when shutdown is detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Add a configuration option to always restart the twitter stream consumer whenever the set of requested follows changes, as opposed to only doing it when changes are additive. In the configuration file: `twitter.always_restart = true`, in command line arguments: `--twitter-always-restart`, in environment variables: `PAJBOT_TWITTER_ALWAYS_RESTART=<anything>`. (#20)
+- Send close frames when the application shuts down (#21)
 
 ## [0.1.1] - 2020-07-04
 

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -105,7 +105,24 @@ async fn handler(
             }
 
             tweet = rx_tweet.next() => {
-                let tweet = tweet.context("fused stream to rx_tweet ran out")?;
+                let tweet = match tweet {
+                    Some(tweet) => tweet,
+                    None => {
+                        // rx_tweet ran out, hopefully we're shutting down
+
+                        use async_tungstenite::tungstenite::protocol;
+
+                        log::info!("closing {}", addr);
+                        tx_ws
+                            .send(Message::Close(Some(protocol::CloseFrame {
+                                code: protocol::frame::coding::CloseCode::Error,
+                                reason: "tweet-provider was interrupted or encountered an error".into(),
+                            })))
+                        .await?;
+
+                        break;
+                    }
+                };
 
                 if let Err(broadcast::RecvError::Lagged(n)) = tweet {
                     log::error!("lagging {} items behind", n);
@@ -134,6 +151,8 @@ async fn handler(
             }
         }
     }
+
+    Ok(())
 }
 
 async fn handle_ws_message<S>(

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -63,7 +63,6 @@ pub async fn listener(
     }
 }
 
-// TODO: send close frames when we gotta
 async fn handler(
     stream: TcpStream,
     addr: SocketAddr,


### PR DESCRIPTION
we also allow running tasks (in our case, websocket handlers) to finish
running, with a timeout of 1 second