### PR TITLE
Use upstream egg-mode 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array",
  "subtle",
@@ -270,8 +270,9 @@ dependencies = [
 
 [[package]]
 name = "egg-mode"
-version = "0.15.0"
-source = "git+https://github.com/RAnders00/egg-mode?branch=tokio-v1.0-upgrade#11dc221533288ebcb1b135c2df65f187a80cd255"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb96b3df2a1dd9fe043e58eed7ba1c835a23561e777e243e8cc08aa4178aec79"
 dependencies = [
  "base64",
  "chrono",
@@ -465,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 anyhow = "1"
 async-stream = "0.3"
 async-tungstenite = { version = "0.17",  features = ["tokio-runtime"] }
-egg-mode = { git = "https://github.com/RAnders00/egg-mode", branch = "tokio-v1.0-upgrade", default-features = false, features = ["rustls"] }
+egg-mode = { version = "0.16", default-features = false, features = ["rustls"] }
 futures = "0.3"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Upstream egg-mode 0.16 has support for tokio1 now, so let's use that!
