### PR TITLE
Migrate from structopt to clap v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,22 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       # same checks as with `cargo build`, but no binaries are generated at the end, saving some time.
       - run: cargo check
+  test:
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os: [ ubuntu, windows, macOS ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hecrj/setup-rust-action@v1
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: cargo test
   check-format:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Migrate from structopt to clap v3. (#255)
+
 ## [0.1.3] - 2021-05-08
 
 - Update underlying dependencies (e.g. tokio from 0.3 to 1.5)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,15 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,17 +156,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -187,6 +202,42 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "concolor"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015267563b1df20adccdd00cb05257b1dfbea70a04928e9cf88ffb850c1a40af"
+dependencies = [
+ "atty",
+ "bitflags",
+ "concolor-query",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6417fe6fc03a8b533fd2177742eeb39a90c7233eedec7bac96d4d6b69a09449"
+
+[[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -218,6 +269,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "once_cell",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -282,6 +378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "egg-mode"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +407,33 @@ dependencies = [
  "thiserror",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys",
 ]
 
 [[package]]
@@ -433,6 +562,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "h2"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,12 +594,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -518,6 +650,22 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hyper"
@@ -595,6 +743,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf247779e67a9082a4790b45e71ac7cfd1321331a5c856a74a9faebdab78d0"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +813,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +838,12 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-integer"
@@ -719,6 +900,22 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "os_pipe"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c92f2b54f081d635c77e7120862d48db8e91f7f21cef23ab1b4fe9971c59f55"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "parking_lot"
@@ -840,6 +1037,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +1085,15 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "ring"
@@ -919,6 +1149,15 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1031,6 +1270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1283,12 @@ checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
 
 [[package]]
 name = "simple_logger"
@@ -1068,6 +1319,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
+name = "snapbox"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d199ccf8f606592df2d145db26f2aa45344e23c64b074cc5a4047f1d99b0f7"
+dependencies = [
+ "concolor",
+ "content_inspector",
+ "dunce",
+ "filetime",
+ "normalize-line-endings",
+ "os_pipe",
+ "similar",
+ "snapbox-macros",
+ "tempfile",
+ "wait-timeout",
+ "walkdir",
+ "yansi",
+]
+
+[[package]]
+name = "snapbox-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a253e6f894cfa440cba00600a249fa90869d8e0ec45ab274a456e043a0ce8f2"
+
+[[package]]
 name = "socket2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,33 +1362,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -1131,13 +1384,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "tempfile"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "unicode-width",
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -1270,6 +1543,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
+ "serde",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +1587,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "trycmd"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ac9fa73959e252e7c5a4e6260544b952f5bf3989e0b7ad229f4fd6f14671b02"
+dependencies = [
+ "glob",
+ "humantime",
+ "humantime-serde",
+ "rayon",
+ "serde",
+ "shlex",
+ "snapbox",
+ "toml_edit",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,16 +1628,17 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-tungstenite",
+ "clap",
  "egg-mode",
  "futures",
  "log",
  "serde",
  "serde_json",
  "simple_logger",
- "structopt",
  "thiserror",
  "tokio",
  "toml",
+ "trycmd",
 ]
 
 [[package]]
@@ -1367,18 +1669,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,16 +1692,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -1526,6 +1830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,3 +1886,9 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 simple_logger = "2.3"
-structopt = "0.3"
+clap = { version = "3", features = ["derive", "env"]}
 thiserror = "1"
 tokio = { version = "1.21", features = ["full"] }
 toml = "0.5"
+
+[dev-dependencies]
+trycmd = "*"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,53 +1,64 @@
 use egg_mode::{self as twitter};
+use clap::{Parser, ValueEnum};
 use serde::{Deserialize, Serialize};
 use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
 };
-use structopt::StructOpt;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum LogTimestamps {
+    Local,
+    UTC,
+    Off,
+}
 
 // This file is mostly boilerplate code
 
 // StructOpt derives an argument parser and environment reader
 // The config is read in this order of fallbacks:
 // Program arguments -> Environment -> Config file
-#[derive(Clone, Debug, StructOpt)]
-#[structopt(rename_all = "kebab")]
+#[derive(Clone, Debug, Parser)]
+#[clap(version, rename_all = "kebab")]
 pub struct Args {
     /// Path to config file in TOML format
-    #[structopt(
-        short = "C",
+    #[clap(
+        short = 'C',
         long = "conf",
         env = "PAJBOT_CONF",
         default_value = "tweet-provider.toml"
     )]
     pub config_path: PathBuf,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub config: Config,
 
     /// Log level filter, either: OFF, ERROR, WARN, INFO, DEBUG, TRACE
-    #[structopt(short = "L", long = "log", default_value = "INFO", env = "PAJBOT_LOG")]
+    #[clap(short = 'L', long = "log", default_value = "INFO", env = "PAJBOT_LOG")]
     pub log_level: log::LevelFilter,
+
+    /// Log message timestamp method
+    #[clap(long = "log-timestamps", arg_enum, default_value = "utc", env = "PAJBOT_LOG_TIMESTAMPS")]
+    pub log_timestamps: LogTimestamps,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, StructOpt)]
+#[derive(Clone, Debug, Deserialize, Serialize, Parser)]
 pub struct Config {
     #[serde(default)]
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub websocket: WebSocket,
 
     #[serde(default)]
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub twitter: Twitter,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, StructOpt)]
+#[derive(Clone, Debug, Deserialize, Serialize, Parser)]
 pub struct WebSocket {
     /// address:port to bind the websocket listener to
     #[serde(default = "WebSocket::default_listen_addr")]
-    #[structopt(
-        short = "l",
+    #[clap(
+        short = 'l',
         long = "listen",
         env = "PAJBOT_LISTEN",
         default_value = "127.0.0.1:2356"
@@ -55,10 +66,10 @@ pub struct WebSocket {
     pub listen_addr: SocketAddr,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, StructOpt)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Parser)]
 pub struct Twitter {
     /// Consumer API key. Found in App's Keys and tokens on https://developer.twitter.com
-    #[structopt(
+    #[clap(
         long = "twitter-consumer-key",
         env = "PAJBOT_TWITTER_CONSUMER_KEY",
         hide_env_values = true
@@ -66,7 +77,7 @@ pub struct Twitter {
     pub consumer_key: Option<String>,
 
     /// Consumer API secret key
-    #[structopt(
+    #[clap(
         long = "twitter-consumer-secret",
         env = "PAJBOT_TWITTER_CONSUMER_SECRET",
         hide_env_values = true
@@ -74,7 +85,7 @@ pub struct Twitter {
     pub consumer_secret: Option<String>,
 
     /// Access token. Found in App's Keys and tokens on https://developer.twitter.com
-    #[structopt(
+    #[clap(
         long = "twitter-access-token",
         env = "PAJBOT_TWITTER_ACCESS_TOKEN",
         hide_env_values = true
@@ -82,19 +93,21 @@ pub struct Twitter {
     pub access_token: Option<String>,
 
     /// Access token secret
-    #[structopt(
+    #[clap(
         long = "twitter-access-token-secret",
         env = "PAJBOT_TWITTER_ACCESS_TOKEN_SECRET",
         hide_env_values = true
     )]
     pub access_token_secret: Option<String>,
 
-    // https://github.com/clap-rs/clap/issues/1476
     /// Always restart the twitter consumer when the requested follows change,
     /// as opposed to only when new follows are added
-    /// [env: PAJBOT_TWITTER_ALWAYS_RESTART]
     #[serde(default)]
-    #[structopt(long = "twitter-always-restart" /*, env = "PAJBOT_TWITTER_ALWAYS_RESTART" */)]
+    #[clap(
+        long = "twitter-always-restart",
+        env = "PAJBOT_TWITTER_ALWAYS_RESTART",
+        hide_env_values = true
+    )]
     pub always_restart: bool,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
-use egg_mode::{self as twitter};
 use clap::{Parser, ValueEnum};
+use egg_mode::{self as twitter};
 use serde::{Deserialize, Serialize};
 use std::{
     net::SocketAddr,
@@ -38,7 +38,12 @@ pub struct Args {
     pub log_level: log::LevelFilter,
 
     /// Log message timestamp method
-    #[clap(long = "log-timestamps", arg_enum, default_value = "utc", env = "PAJBOT_LOG_TIMESTAMPS")]
+    #[clap(
+        long = "log-timestamps",
+        arg_enum,
+        default_value = "utc",
+        env = "PAJBOT_LOG_TIMESTAMPS"
+    )]
     pub log_timestamps: LogTimestamps,
 }
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,0 +1,5 @@
+#[test]
+fn cli_tests() {
+    trycmd::TestCases::new()
+        .case("tests/cmd/*.toml");
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,5 +1,4 @@
 #[test]
 fn cli_tests() {
-    trycmd::TestCases::new()
-        .case("tests/cmd/*.toml");
+    trycmd::TestCases::new().case("tests/cmd/*.toml");
 }

--- a/tests/cmd/V_flag_stdout.toml
+++ b/tests/cmd/V_flag_stdout.toml
@@ -1,0 +1,7 @@
+bin.name = "tweet-provider"
+args = ["-V"]
+status.code = 0
+stdout = """
+tweet-provider 0.1.2
+"""
+stderr = ""

--- a/tests/cmd/default_args.stdout
+++ b/tests/cmd/default_args.stdout
@@ -1,0 +1,17 @@
+Args {
+    config_path: "tweet-provider.toml",
+    config: Config {
+        websocket: WebSocket {
+            listen_addr: 127.0.0.1:2356,
+        },
+        twitter: Twitter {
+            consumer_key: None,
+            consumer_secret: None,
+            access_token: None,
+            access_token_secret: None,
+            always_restart: false,
+        },
+    },
+    log_level: Info,
+    log_timestamps: UTC,
+}

--- a/tests/cmd/default_args.toml
+++ b/tests/cmd/default_args.toml
@@ -1,0 +1,6 @@
+bin.name = "tweet-provider"
+
+status.code = 0
+
+[env.add]
+TWEET_PROVIDER_DUMP_ARGS_AND_EXIT = "1"

--- a/tests/cmd/h_flag.toml
+++ b/tests/cmd/h_flag.toml
@@ -1,0 +1,50 @@
+bin.name = "tweet-provider"
+args = ["-h"]
+status.code = 0
+stdout = """
+tweet-provider 0.1.2
+
+USAGE:
+    tweet-provider [OPTIONS]
+
+OPTIONS:
+    -C, --conf <CONFIG_PATH>
+            Path to config file in TOML format [env: PAJBOT_CONF=] [default: tweet-provider.toml]
+
+    -h, --help
+            Print help information
+
+    -l, --listen <LISTEN_ADDR>
+            address:port to bind the websocket listener to [env: PAJBOT_LISTEN=] [default:
+            127.0.0.1:2356]
+
+    -L, --log <LOG_LEVEL>
+            Log level filter, either: OFF, ERROR, WARN, INFO, DEBUG, TRACE [env: PAJBOT_LOG=]
+            [default: INFO]
+
+        --log-timestamps <LOG_TIMESTAMPS>
+            Log message timestamp method [env: PAJBOT_LOG_TIMESTAMPS=] [default: utc] [possible
+            values: local, utc, off]
+
+        --twitter-access-token <ACCESS_TOKEN>
+            Access token. Found in App's Keys and tokens on https://developer.twitter.com [env:
+            PAJBOT_TWITTER_ACCESS_TOKEN]
+
+        --twitter-access-token-secret <ACCESS_TOKEN_SECRET>
+            Access token secret [env: PAJBOT_TWITTER_ACCESS_TOKEN_SECRET]
+
+        --twitter-always-restart
+            Always restart the twitter consumer when the requested follows change, as opposed to
+            only when new follows are added [env: PAJBOT_TWITTER_ALWAYS_RESTART]
+
+        --twitter-consumer-key <CONSUMER_KEY>
+            Consumer API key. Found in App's Keys and tokens on https://developer.twitter.com [env:
+            PAJBOT_TWITTER_CONSUMER_KEY]
+
+        --twitter-consumer-secret <CONSUMER_SECRET>
+            Consumer API secret key [env: PAJBOT_TWITTER_CONSUMER_SECRET]
+
+    -V, --version
+            Print version information
+"""
+stderr = ""

--- a/tests/cmd/h_flag.toml
+++ b/tests/cmd/h_flag.toml
@@ -5,7 +5,7 @@ stdout = """
 tweet-provider 0.1.2
 
 USAGE:
-    tweet-provider [OPTIONS]
+    tweet-provider[EXE] [OPTIONS]
 
 OPTIONS:
     -C, --conf <CONFIG_PATH>

--- a/tests/cmd/twitter_consumer_key_arg.stdout
+++ b/tests/cmd/twitter_consumer_key_arg.stdout
@@ -1,0 +1,19 @@
+Args {
+    config_path: "tweet-provider.toml",
+    config: Config {
+        websocket: WebSocket {
+            listen_addr: 127.0.0.1:2356,
+        },
+        twitter: Twitter {
+            consumer_key: Some(
+                "test",
+            ),
+            consumer_secret: None,
+            access_token: None,
+            access_token_secret: None,
+            always_restart: false,
+        },
+    },
+    log_level: Info,
+    log_timestamps: UTC,
+}

--- a/tests/cmd/twitter_consumer_key_arg.toml
+++ b/tests/cmd/twitter_consumer_key_arg.toml
@@ -1,0 +1,8 @@
+bin.name = "tweet-provider"
+
+status.code = 0
+
+args = ["--twitter-consumer-key=test"]
+
+[env.add]
+TWEET_PROVIDER_DUMP_ARGS_AND_EXIT = "1"

--- a/tests/cmd/twitter_consumer_key_arg_override.in/tweet-provider.toml
+++ b/tests/cmd/twitter_consumer_key_arg_override.in/tweet-provider.toml
@@ -1,0 +1,2 @@
+[twitter]
+consumer_key = "foo"

--- a/tests/cmd/twitter_consumer_key_arg_override.stdout
+++ b/tests/cmd/twitter_consumer_key_arg_override.stdout
@@ -1,0 +1,16 @@
+Config {
+    websocket: WebSocket {
+        listen_addr: 127.0.0.1:2356,
+    },
+    twitter: Twitter {
+        consumer_key: Some(
+            "fromarg",
+        ),
+        consumer_secret: None,
+        access_token: None,
+        access_token_secret: None,
+        always_restart: false,
+    },
+}
+INFO  [tweet_provider] waiting one second for tasks to end
+INFO  [tweet_provider] exiting

--- a/tests/cmd/twitter_consumer_key_arg_override.toml
+++ b/tests/cmd/twitter_consumer_key_arg_override.toml
@@ -1,0 +1,10 @@
+bin.name = "tweet-provider"
+
+status.code = 0
+
+args = ["--twitter-consumer-key=fromarg"]
+
+[env.add]
+TWEET_PROVIDER_DUMP_CONFIG_AND_EXIT = "1"
+PAJBOT_LOG_TIMESTAMPS = "off"
+PAJBOT_TWITTER_CONSUMER_KEY = "fromenv"

--- a/tests/cmd/twitter_consumer_key_config.in/tweet-provider.toml
+++ b/tests/cmd/twitter_consumer_key_config.in/tweet-provider.toml
@@ -1,0 +1,2 @@
+[twitter]
+consumer_key = "foo"

--- a/tests/cmd/twitter_consumer_key_config.stdout
+++ b/tests/cmd/twitter_consumer_key_config.stdout
@@ -1,0 +1,16 @@
+Config {
+    websocket: WebSocket {
+        listen_addr: 127.0.0.1:2356,
+    },
+    twitter: Twitter {
+        consumer_key: Some(
+            "foo",
+        ),
+        consumer_secret: None,
+        access_token: None,
+        access_token_secret: None,
+        always_restart: false,
+    },
+}
+INFO  [tweet_provider] waiting one second for tasks to end
+INFO  [tweet_provider] exiting

--- a/tests/cmd/twitter_consumer_key_config.toml
+++ b/tests/cmd/twitter_consumer_key_config.toml
@@ -1,0 +1,7 @@
+bin.name = "tweet-provider"
+
+status.code = 0
+
+[env.add]
+TWEET_PROVIDER_DUMP_CONFIG_AND_EXIT = "1"
+PAJBOT_LOG_TIMESTAMPS = "off"

--- a/tests/cmd/twitter_consumer_key_env.stdout
+++ b/tests/cmd/twitter_consumer_key_env.stdout
@@ -1,0 +1,19 @@
+Args {
+    config_path: "tweet-provider.toml",
+    config: Config {
+        websocket: WebSocket {
+            listen_addr: 127.0.0.1:2356,
+        },
+        twitter: Twitter {
+            consumer_key: Some(
+                "test",
+            ),
+            consumer_secret: None,
+            access_token: None,
+            access_token_secret: None,
+            always_restart: false,
+        },
+    },
+    log_level: Info,
+    log_timestamps: UTC,
+}

--- a/tests/cmd/twitter_consumer_key_env.toml
+++ b/tests/cmd/twitter_consumer_key_env.toml
@@ -1,0 +1,7 @@
+bin.name = "tweet-provider"
+
+status.code = 0
+
+[env.add]
+TWEET_PROVIDER_DUMP_ARGS_AND_EXIT = "1"
+PAJBOT_TWITTER_CONSUMER_KEY = "test"

--- a/tests/cmd/twitter_consumer_key_env_override.in/tweet-provider.toml
+++ b/tests/cmd/twitter_consumer_key_env_override.in/tweet-provider.toml
@@ -1,0 +1,2 @@
+[twitter]
+consumer_key = "foo"

--- a/tests/cmd/twitter_consumer_key_env_override.stdout
+++ b/tests/cmd/twitter_consumer_key_env_override.stdout
@@ -1,0 +1,16 @@
+Config {
+    websocket: WebSocket {
+        listen_addr: 127.0.0.1:2356,
+    },
+    twitter: Twitter {
+        consumer_key: Some(
+            "fromenv",
+        ),
+        consumer_secret: None,
+        access_token: None,
+        access_token_secret: None,
+        always_restart: false,
+    },
+}
+INFO  [tweet_provider] waiting one second for tasks to end
+INFO  [tweet_provider] exiting

--- a/tests/cmd/twitter_consumer_key_env_override.toml
+++ b/tests/cmd/twitter_consumer_key_env_override.toml
@@ -1,0 +1,8 @@
+bin.name = "tweet-provider"
+
+status.code = 0
+
+[env.add]
+TWEET_PROVIDER_DUMP_CONFIG_AND_EXIT = "1"
+PAJBOT_LOG_TIMESTAMPS = "off"
+PAJBOT_TWITTER_CONSUMER_KEY = "fromenv"


### PR DESCRIPTION
Structopt is in archive mode, and clap v3 has very similar functionality

In addition to just migrating, to be able to test this I have also
changed the following things:
 - log timestamp can now be configured/disabled with --log-timestamps
   this allows us to disable timestamps to get consistent output for tests
 - clap v3 doesn't have the same issue with environment variables, so
   PAJBOT_TWITTER_ALWAYS_RESTART can now be more streamlined
 - TWEET_PROVIDER_DUMP_CONFIG_AND_EXIT/TWEET_PROVIDER_DUMP_ARGS_AND_EXIT
   can be used to dump args/configs on startup - this is mainly to
   facilitate testing the CLI to ensure no functionality has been broken
