### PR TITLE
Update clap to v4.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.32"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+checksum = "4ec7a4128863c188deefe750ac1d1dfe66c236909f845af04beed823638dc1b2"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.17"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 simple_logger = "4.0.0"
-clap = { version = "4.0.32", features = ["derive", "env"]}
+clap = { version = "4.1.1", features = ["derive", "env"]}
 thiserror = "1.0.38"
 tokio = { version = "1.24.2", features = ["full"] }
 toml = "0.5.11"

--- a/tests/cmd/h_flag.toml
+++ b/tests/cmd/h_flag.toml
@@ -26,6 +26,6 @@ Options:
   -h, --help
           Print help
   -V, --version
-          Print version information
+          Print version
 """
 stderr = ""

--- a/tests/cmd/h_flag.toml
+++ b/tests/cmd/h_flag.toml
@@ -24,7 +24,7 @@ Options:
       --log-timestamps <LOG_TIMESTAMPS>
           Log message timestamp method [env: PAJBOT_LOG_TIMESTAMPS=] [default: utc] [possible values: local, utc, off]
   -h, --help
-          Print help information
+          Print help
   -V, --version
           Print version information
 """


### PR DESCRIPTION
- Update clap to v4.1.1
- clap builtin `--help` no longer includes the "information" suffix
- clap builtin `--version` no longer includes "information" suffix
