### PR TITLE
Fix backoff overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Migrate from structopt to clap v3. (#255)
+- Fix an issue where the backoff when connections fail can overflow and cause the delay to be 0s, causing connections to be spammed. (#382)
 
 ## [0.1.3] - 2021-05-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,6 +1823,8 @@ dependencies = [
  "clap",
  "egg-mode",
  "futures",
+ "http",
+ "hyper",
  "log",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,8 +1823,6 @@ dependencies = [
  "clap",
  "egg-mode",
  "futures",
- "http",
- "hyper",
  "log",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+dependencies = [
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,6 +1848,7 @@ dependencies = [
  "egg-mode",
  "futures",
  "log",
+ "rstest",
  "serde",
  "serde_json",
  "simple_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,6 @@ tokio = { version = "1.28.1", features = ["full"] }
 toml = "0.7.4"
 
 [dev-dependencies]
+http = "0.2.9"
+hyper = "0.14.26"
 trycmd = "0.14.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,5 @@ tokio = { version = "1.28.1", features = ["full"] }
 toml = "0.7.4"
 
 [dev-dependencies]
+rstest = { version = "0.17.0", default-features = false }
 trycmd = "0.14.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,4 @@ tokio = { version = "1.28.1", features = ["full"] }
 toml = "0.7.4"
 
 [dev-dependencies]
-http = "0.2.9"
-hyper = "0.14.26"
 trycmd = "0.14.16"

--- a/src/twitter.rs
+++ b/src/twitter.rs
@@ -272,186 +272,92 @@ async fn stream_consumer(
 #[cfg(test)]
 mod test {
     use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn test_420() {
-        let mut backoff: u32 = 0;
-
+    #[rstest]
+    #[case(0, Duration::from_secs(60), 1)]
+    #[case(1, Duration::from_secs(120), 2)]
+    #[case(2, Duration::from_secs(240), 3)]
+    #[case(3, Duration::from_secs(480), 4)]
+    #[case(4, Duration::from_secs(960), 5)]
+    #[case(5, Duration::from_secs(960), 6)]
+    #[case(100, Duration::from_secs(960), 101)]
+    #[case(u32::MAX-1, Duration::from_secs(960), u32::MAX)]
+    #[case(u32::MAX, Duration::from_secs(960), u32::MAX)]
+    fn test_420(
+        #[case] mut initial_backoff: u32,
+        #[case] expected_duration: Duration,
+        #[case] expected_backoff: u32,
+    ) {
         let error = ErrorKind::RateLimited;
 
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 1);
-        assert_eq!(dur, Duration::from_secs(60));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 2);
-        assert_eq!(dur, Duration::from_secs(120));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 3);
-        assert_eq!(dur, Duration::from_secs(240));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 4);
-        assert_eq!(dur, Duration::from_secs(480));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 5);
-        assert_eq!(dur, Duration::from_secs(960));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 6);
-        assert_eq!(dur, Duration::from_secs(960));
-
-        backoff = 100;
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 101);
-        assert_eq!(dur, Duration::from_secs(960));
-
-        backoff = u32::MAX - 1;
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, u32::MAX);
-        assert_eq!(dur, Duration::from_secs(960));
-
-        backoff = u32::MAX;
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, u32::MAX);
-        assert_eq!(dur, Duration::from_secs(960));
+        let dur = inspect_error(error, &mut initial_backoff);
+        assert_eq!(initial_backoff, expected_backoff);
+        assert_eq!(dur, expected_duration);
     }
 
-    #[test]
-    fn test_bad_status() {
-        let mut backoff: u32 = 0;
-
+    #[rstest]
+    #[case(0, Duration::from_secs(5), 1)]
+    #[case(1, Duration::from_secs(10), 2)]
+    #[case(2, Duration::from_secs(20), 3)]
+    #[case(3, Duration::from_secs(40), 4)]
+    #[case(4, Duration::from_secs(80), 5)]
+    #[case(5, Duration::from_secs(160), 6)]
+    #[case(6, Duration::from_secs(320), 7)]
+    #[case(7, Duration::from_secs(320), 8)]
+    #[case(100, Duration::from_secs(320), 101)]
+    #[case(u32::MAX-1, Duration::from_secs(320), u32::MAX)]
+    #[case(u32::MAX, Duration::from_secs(320), u32::MAX)]
+    fn test_bad_status(
+        #[case] mut initial_backoff: u32,
+        #[case] expected_duration: Duration,
+        #[case] expected_backoff: u32,
+    ) {
         let error = ErrorKind::BadStatus;
 
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 1);
-        assert_eq!(dur, Duration::from_secs(5));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 2);
-        assert_eq!(dur, Duration::from_secs(10));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 3);
-        assert_eq!(dur, Duration::from_secs(20));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 4);
-        assert_eq!(dur, Duration::from_secs(40));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 5);
-        assert_eq!(dur, Duration::from_secs(80));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 6);
-        assert_eq!(dur, Duration::from_secs(160));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 7);
-        assert_eq!(dur, Duration::from_secs(320));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 8);
-        assert_eq!(dur, Duration::from_secs(320));
-
-        backoff = 100;
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 101);
-        assert_eq!(dur, Duration::from_secs(320));
-
-        backoff = u32::MAX - 1;
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, u32::MAX);
-        assert_eq!(dur, Duration::from_secs(320));
-
-        backoff = u32::MAX;
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, u32::MAX);
-        assert_eq!(dur, Duration::from_secs(320));
+        let dur = inspect_error(error, &mut initial_backoff);
+        assert_eq!(initial_backoff, expected_backoff);
+        assert_eq!(dur, expected_duration);
     }
 
-    #[test]
-    fn test_net() {
-        let mut backoff: u32 = 0;
-
+    #[rstest]
+    #[case(0, Duration::from_millis(250), 1)]
+    #[case(1, Duration::from_millis(250), 2)]
+    #[case(2, Duration::from_millis(500), 3)]
+    #[case(3, Duration::from_millis(750), 4)]
+    #[case(4, Duration::from_millis(1_000), 5)]
+    #[case(5, Duration::from_millis(1_250), 6)]
+    #[case(100, Duration::from_secs(16), 101)]
+    #[case(u32::MAX-1, Duration::from_secs(16), u32::MAX)]
+    #[case(u32::MAX, Duration::from_secs(16), u32::MAX)]
+    fn test_net(
+        #[case] mut initial_backoff: u32,
+        #[case] expected_duration: Duration,
+        #[case] expected_backoff: u32,
+    ) {
         let error = ErrorKind::NetError;
 
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 1);
-        assert_eq!(dur, Duration::from_millis(250));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 2);
-        assert_eq!(dur, Duration::from_millis(250));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 3);
-        assert_eq!(dur, Duration::from_millis(500));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 4);
-        assert_eq!(dur, Duration::from_millis(750));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 5);
-        assert_eq!(dur, Duration::from_millis(1_000));
-
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 6);
-        assert_eq!(dur, Duration::from_millis(1_250));
-
-        backoff = 100;
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 101);
-        assert_eq!(dur, Duration::from_secs(16));
-
-        backoff = u32::MAX - 1;
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, u32::MAX);
-        assert_eq!(dur, Duration::from_secs(16));
-
-        backoff = u32::MAX;
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, u32::MAX);
-        assert_eq!(dur, Duration::from_secs(16));
+        let dur = inspect_error(error, &mut initial_backoff);
+        assert_eq!(initial_backoff, expected_backoff);
+        assert_eq!(dur, expected_duration);
     }
 
-    #[test]
-    fn test_unspecified() {
-        let mut backoff: u32 = 0;
-
+    #[rstest]
+    #[case(0, Duration::from_millis(250), 0)]
+    #[case(1, Duration::from_millis(250), 0)]
+    #[case(2, Duration::from_millis(250), 0)]
+    #[case(100, Duration::from_millis(250), 0)]
+    #[case(u32::MAX-1, Duration::from_millis(250), 0)]
+    #[case(u32::MAX, Duration::from_millis(250), 0)]
+    fn test_unspecific(
+        #[case] mut initial_backoff: u32,
+        #[case] expected_duration: Duration,
+        #[case] expected_backoff: u32,
+    ) {
         let error = ErrorKind::Unspecific;
 
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 0);
-        assert_eq!(dur, Duration::from_millis(250));
-
-        backoff = 1;
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 0);
-        assert_eq!(dur, Duration::from_millis(250));
-
-        backoff = 5;
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 0);
-        assert_eq!(dur, Duration::from_millis(250));
-
-        backoff = 100;
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 0);
-        assert_eq!(dur, Duration::from_millis(250));
-
-        backoff = u32::MAX - 1;
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 0);
-        assert_eq!(dur, Duration::from_millis(250));
-
-        backoff = u32::MAX;
-        let dur = inspect_error(error, &mut backoff);
-        assert_eq!(backoff, 0);
-        assert_eq!(dur, Duration::from_millis(250));
+        let dur = inspect_error(error, &mut initial_backoff);
+        assert_eq!(initial_backoff, expected_backoff);
+        assert_eq!(dur, expected_duration);
     }
 }


### PR DESCRIPTION
## Description

Initial solution I went for was to just mock the errors and pass them into inspect_error as is, but hyper does *not* allow for mocking of the error, so I couldn't add any tests to the NetError case. The solution to that is to use our own abstract `ErrorKind` enum that handles the conversion from `anyhow::Error(...)` to `ErrorKind`, so the test can just use that.

## How has this been tested?

1. I have ran the unit tests that I created
2. I have run this in my production environment, and I'm seeing the backoff timer increase as expected. I have run it long enough that the backoff should have occurred, yet it hasn't.

Fixes #381
